### PR TITLE
fix: add robust error handling in spider and live server

### DIFF
--- a/dy_live/server.py
+++ b/dy_live/server.py
@@ -2,6 +2,7 @@ import gzip
 import threading
 import time
 from urllib.parse import urlencode
+from loguru import logger
 
 from websocket import WebSocketApp
 
@@ -82,8 +83,7 @@ class DouyinLive:
 
             # s = zlib.decompress(decode_str).decode()
         except Exception as e:
-            print('error')
-            print(str(e))
+            logger.error(f'Error processing live message: {e}')
 
     def on_error(self, ws, error):
         print("\033[31m### error ###")
@@ -162,7 +162,7 @@ class DouyinLive:
         try:
             self.ws.run_forever(origin='https://live.douyin.com')
         except Exception as e:
-            print(str(e))
+            logger.error(f'Error starting websocket: {e}')
             self.ws.close()
 
 

--- a/main.py
+++ b/main.py
@@ -20,6 +20,9 @@ class Data_Spider():
         :return:
         """
         res_json = self.douyin_apis.get_work_info(auth, work_url)
+        if not res_json or 'aweme_detail' not in res_json:
+            logger.error(f'获取作品信息失败 {work_url}: {res_json}')
+            return None
         data = res_json['aweme_detail']
 
         work_info = handle_work_info(data)
@@ -41,7 +44,8 @@ class Data_Spider():
         work_list = []
         for work_url in works:
             work_info = self.spider_work(auth, work_url)
-            work_list.append(work_info)
+            if work_info:
+                work_list.append(work_info)
         for work_info in work_list:
             if save_choice == 'all' or 'media' in save_choice:
                 download_work(work_info, base_path['media'], save_choice)
@@ -144,4 +148,3 @@ if __name__ == '__main__':
     content_type = "0"  # 内容形式 0 不限, 1 视频, 2 图文
 
     data_spider.spider_some_search_work(auth, query, require_num, base_path, 'all', sort_type, publish_time, filter_duration, search_range, content_type)
-


### PR DESCRIPTION
This change enhances the stability of the Douyin spider and live stream processing. 

In `main.py`, the `spider_work` method now verifies that the API response contains the expected `aweme_detail` field before processing, preventing `KeyError` crashes when requests return unexpected data or fail. The `spider_some_work` method was updated to safely handle cases where `spider_work` returns `None` due to a failed API call, ensuring that the script continues processing other works instead of terminating prematurely.

In `dy_live/server.py`, the generic `try...except` block in `on_message` has been updated to use `loguru` for structured error logging, providing better visibility into processing errors during live stream monitoring without crashing the WebSocket connection.